### PR TITLE
1letter/dev

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Changelog
 - Update to Python3
   [1letter]
 
+- Add plone.autoform.directives Support for Widget
+- Add css klass to Widget
+  [1letter]
+
 
 1.4.4 (2016-07-20)
 ~~~~~~~~~~~~~~~~~~

--- a/src/collective/z3cform/norobots/tests/doctests.rst
+++ b/src/collective/z3cform/norobots/tests/doctests.rst
@@ -14,11 +14,11 @@ browser/plone_forms .
 
 	>>> from zope.component import getUtility
     >>> from plone.registry.interfaces import IRegistry
-    
+
     >>> app = layer['app']
     >>> portal = layer['portal']
     >>> request = layer['request']
-    
+
     >>> registry = getUtility(IRegistry)
     >>> norobots_settings = registry.forInterface(INorobotsWidgetSettings)
 
@@ -81,7 +81,7 @@ A widget with an empty captcha is rendered if there is no question/answer:
 
     # Tthe widget may be rendered differently but it is always the same (depends on the Plone version)
     >>> foo_form.widgets['norobots'].render() in [
-    ...       u'\n\t\n  <strong><span>Question</span></strong>:\n  <span></span><br />\n\n  <strong><span>Your answer</span></strong>:\n  \n  <input type="text" id="form-widgets-norobots" name="form.widgets.norobots" class="text-widget required textline-field" size="30" maxlength="200" value="" />\n                     \n  <input type="hidden" name="question_id" value="" />\n  <input type="hidden" name="id_check" value="" />\n         \n'
+    ...       u'\n\t\n  <strong><span>Question</span></strong>:\n  <span></span><br />\n\n  <strong><span>Your answer</span></strong>:\n  \n  <input type="text" id="form-widgets-norobots" name="form.widgets.norobots" class="norobots-widget required textline-field" size="30" maxlength="200" value="" />\n                     \n  <input type="hidden" name="question_id" value="" />\n  <input type="hidden" name="id_check" value="" />\n         \n'
     ...       ]
     True
 

--- a/src/collective/z3cform/norobots/widget.py
+++ b/src/collective/z3cform/norobots/widget.py
@@ -1,10 +1,16 @@
 from Acquisition import aq_inner
+from zope.component import adapter
 from zope.component import getMultiAdapter
+from zope.interface import implementer
 from zope.interface import implementer_only
+from zope.schema.interfaces import IField
 
 from z3c.form.interfaces import IWidget
+from z3c.form.interfaces import IFieldWidget
+from z3c.form.interfaces import IFormLayer
 from z3c.form.widget import FieldWidget
 from z3c.form.browser.text import TextWidget
+
 
 class INorobotsWidget(IWidget):
     """Marker interface for th norobots widget
@@ -23,6 +29,8 @@ class NorobotsWidget(TextWidget):
         self.norobots = getMultiAdapter((aq_inner(self.context), self.request), name='norobots')
         return self.norobots.get_question()
 
+@adapter(IField, IFormLayer)
+@implementer(IFieldWidget)
 def NorobotsFieldWidget(field, request):
     """IFieldWidget factory for NorobotsWidget."""
     return FieldWidget(field, NorobotsWidget(request))

--- a/src/collective/z3cform/norobots/widget.py
+++ b/src/collective/z3cform/norobots/widget.py
@@ -23,6 +23,8 @@ class NorobotsWidget(TextWidget):
 
     maxlength = 200
     size = 30
+    klass = u'norobots-widget'
+    css = u'norobots'
 
     def get_question(self):
         # return a dictionary {'id': '...', 'title': '...', 'id_check': '...'}


### PR DESCRIPTION
- Add missing Interface to Widget Definition to support plone.autoform
- Add CSS klass to Widget
- Update Changelog
- Update doctest

Example:

Add Widget with plone.autoform.directives

```
from plone.autoform import directives
import from collective.z3cform.norobots.widget import NorobotsFieldWidget

directives.widget('norobots', NorobotsFieldWidget)
norobots = schema.TextLine(
    title = _(u'In order to avoid spam, please answer the question below.'),
    required = True
)
```
