### PR TITLE
Update translations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,12 @@ Changelog
 - Add css klass to Widget
   [1letter]
 
+- Add missing english translation file
+  [thomasmassmann]
+
+- Update translations.
+  [thomasmassmann]
+
 
 1.4.4 (2016-07-20)
 ~~~~~~~~~~~~~~~~~~

--- a/src/collective/z3cform/norobots/locales/collective.z3cform.norobots.pot
+++ b/src/collective/z3cform/norobots/locales/collective.z3cform.norobots.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-04-09 10:58+0000\n"
+"POT-Creation-Date: 2020-06-24 07:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,106 +15,101 @@ msgstr ""
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: collective.pfg.norobots\n"
+"Domain: collective.z3cform.norobots\n"
 
-#: ./plone_forms/contact_info.py:32
+#: ./browser/norobots_macro.pt:18
+#: ./plone_forms/contact_info.py:43
 msgid "Are you a human ?"
 msgstr ""
 
-#: ./plone_forms/contact_info.py:42
+#: ./plone_forms/contact_info.py:55
 msgid "Contact form"
 msgstr ""
 
-#: ./plone_forms/contact_info.py:19
+#: ./plone_forms/contact_info.py:24
 msgid "E-Mail"
 msgstr ""
 
-#: ./plone_forms/contact_info.py:33
+#: ./browser/norobots_macro.pt:28
+#: ./plone_forms/contact_info.py:44
 msgid "In order to avoid spam, please answer the question below."
 msgstr ""
 
-#: ./plone_forms/contact_info.py:132
+#: ./plone_forms/contact_info.py:149
 msgid "Mail sent."
 msgstr ""
 
-#: ./plone_forms/contact_info.py:28
+#: ./plone_forms/contact_info.py:37
 msgid "Message"
 msgstr ""
 
-#: ./plone_forms/contact_info.py:15
+#: ./plone_forms/contact_info.py:20
 msgid "Name"
 msgstr ""
 
-#: Profile title in configure.zcml
+#: ./configure.zcml:51
 msgid "Norobots captcha field (collective.z3cform.norobots)"
 msgstr ""
 
-#: ./browser/interfaces.py:9
+#: ./configure.zcml:60
+msgid "Norobots captcha field UNINSTALLATION"
+msgstr ""
+
+#: ./browser/interfaces.py:11
 msgid "Norobots question::answer"
 msgstr ""
 
-#: ./browser/controlpanel.py:17
+#: ./browser/controlpanel.py:19
 #: ./profiles/default/controlpanel.xml
 msgid "Norobots widget settings"
 msgstr ""
 
-#: ./plone_forms/contact_info.py:83
+#: ./plone_forms/contact_info.py:96
 msgid "Please correct the indicated errors and don't forget to fill in the field 'Are you a human ?'."
 msgstr ""
 
-#: ./plone_forms/contact_info.py:29
+#: ./plone_forms/contact_info.py:38
 msgid "Please enter the message you want to send."
 msgstr ""
 
-#: ./plone_forms/contact_info.py:25
+#: ./plone_forms/contact_info.py:32
 msgid "Please enter the subject of the message you want to send."
 msgstr ""
 
-#: ./plone_forms/contact_info.py:20
+#: ./plone_forms/contact_info.py:25
 msgid "Please enter your e-mail address."
 msgstr ""
 
-#: ./plone_forms/contact_info.py:16
+#: ./plone_forms/contact_info.py:20
 msgid "Please enter your full name."
 msgstr ""
 
-#: Profile description in configure.zcml
+#: ./configure.zcml:51
 msgid "Provides a human captcha widget based on a list of questions/answers."
 msgstr ""
 
-#: ./norobots_input.pt:3
+#: ./browser/norobots_macro.pt:32
+#: ./norobots_input.pt:6
 msgid "Question"
 msgstr ""
 
-#: ./browser/interfaces.py:10
+#: ./browser/interfaces.py:12
 msgid "Questions list (one per line). Example : 'What is 10 + 12 ?::22'. Answer can contain multiple values delimited by semicolon. Example : 'What is 5 + 5 ?::10;ten'."
 msgstr ""
 
-#: ./plone_forms/contact_info.py:77
+#: ./configure.zcml:60
+msgid "Removes the human usable captcha widget based on a list of questions/answers."
+msgstr ""
+
+#: ./plone_forms/contact_info.py:90
 msgid "Send"
 msgstr ""
 
-#: ./plone_forms/contact_info.py:24
+#: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr ""
 
-#: ./plone_forms/contact_info.py:127
-msgid "Unable to send mail: ${exception}"
-msgstr ""
-
-#: ./browser/interfaces.py:15
-msgid "What is 10 + 4 ?"
-msgstr ""
-
-#: ./browser/interfaces.py:14
-msgid "What is 4 + 4 ?"
-msgstr ""
-
-#: ./browser/interfaces.py:16
-msgid "Write five cipher."
-msgstr ""
-
-#: ./validator.py:12
+#: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."
 msgstr ""
 
@@ -122,7 +117,7 @@ msgstr ""
 msgid "You entered an invalid email address."
 msgstr ""
 
-#: ./norobots_input.pt:7
+#: ./browser/norobots_macro.pt:37
+#: ./norobots_input.pt:14
 msgid "Your answer"
 msgstr ""
-

--- a/src/collective/z3cform/norobots/locales/collective.z3cform.norobots.pot
+++ b/src/collective/z3cform/norobots/locales/collective.z3cform.norobots.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-06-24 07:33+0000\n"
+"POT-Creation-Date: 2020-06-24 08:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -107,6 +107,18 @@ msgstr ""
 
 #: ./plone_forms/contact_info.py:31
 msgid "Subject"
+msgstr ""
+
+#: Default question 3
+msgid "What is 10 + 4 ?"
+msgstr ""
+
+#: Default question 1
+msgid "What is 4 + 4 ?"
+msgstr ""
+
+#: Default question 2
+msgid "Write five cipher."
 msgstr ""
 
 #: ./validator.py:9

--- a/src/collective/z3cform/norobots/locales/cs/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/cs/LC_MESSAGES/collective.z3cform.norobots.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: nocaptcha\n"
-"POT-Creation-Date: 2013-04-09 10:58+0000\n"
+"POT-Creation-Date: 2020-06-24 07:33+0000\n"
 "PO-Revision-Date: 2010-10-09 12:32+0100\n"
 "Last-Translator: Radim Novotny <novotny.radim@gmail.com>\n"
 "Language-Team: Czech <info@dms4u.cz>\n"
@@ -14,104 +14,99 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.z3cform.norobots\n"
 
-#: ./plone_forms/contact_info.py:32
+#: ./browser/norobots_macro.pt:18
+#: ./plone_forms/contact_info.py:43
 msgid "Are you a human ?"
 msgstr "Jste člověk?"
 
-#: ./plone_forms/contact_info.py:42
+#: ./plone_forms/contact_info.py:55
 msgid "Contact form"
 msgstr "Kontaktní formulář"
 
-#: ./plone_forms/contact_info.py:19
+#: ./plone_forms/contact_info.py:24
 msgid "E-Mail"
 msgstr "E-Mail"
 
-#: ./plone_forms/contact_info.py:33
+#: ./browser/norobots_macro.pt:28
+#: ./plone_forms/contact_info.py:44
 msgid "In order to avoid spam, please answer the question below."
 msgstr "Zadejte prosím odpověď na níže uvedenou otázku. Jedná se o ochranu proti nevyžádaným příspěvkům."
 
-#: ./plone_forms/contact_info.py:132
+#: ./plone_forms/contact_info.py:149
 msgid "Mail sent."
 msgstr "Email byl odeslán"
 
-#: ./plone_forms/contact_info.py:28
+#: ./plone_forms/contact_info.py:37
 msgid "Message"
 msgstr "Zpráva"
 
-#: ./plone_forms/contact_info.py:15
+#: ./plone_forms/contact_info.py:20
 msgid "Name"
 msgstr "Jméno"
 
-#: Profile title in configure.zcml
+#: ./configure.zcml:51
 msgid "Norobots captcha field (collective.z3cform.norobots)"
 msgstr ""
 
-#: ./browser/interfaces.py:9
+#: ./configure.zcml:60
+msgid "Norobots captcha field UNINSTALLATION"
+msgstr ""
+
+#: ./browser/interfaces.py:11
 msgid "Norobots question::answer"
 msgstr ""
 
-#: ./browser/controlpanel.py:17
+#: ./browser/controlpanel.py:19
 #: ./profiles/default/controlpanel.xml
 msgid "Norobots widget settings"
 msgstr ""
 
-#: ./plone_forms/contact_info.py:83
+#: ./plone_forms/contact_info.py:96
 msgid "Please correct the indicated errors and don't forget to fill in the field 'Are you a human ?'."
 msgstr """Opravte prosím vyznačené chyby a nezapoměňte vyplnit pole "Jste člověk?" """
 
-#: ./plone_forms/contact_info.py:29
+#: ./plone_forms/contact_info.py:38
 msgid "Please enter the message you want to send."
 msgstr "Zadejte prosím zprávu."
 
-#: ./plone_forms/contact_info.py:25
+#: ./plone_forms/contact_info.py:32
 msgid "Please enter the subject of the message you want to send."
 msgstr "Zadejte prosím předmět zprávy, kterou chcete odeslat."
 
-#: ./plone_forms/contact_info.py:20
+#: ./plone_forms/contact_info.py:25
 msgid "Please enter your e-mail address."
 msgstr "Zadejte prosím vaši email adresu"
 
-#: ./plone_forms/contact_info.py:16
+#: ./plone_forms/contact_info.py:20
 msgid "Please enter your full name."
 msgstr "Zadejte prosím vaše jméno"
 
-#: Profile description in configure.zcml
+#: ./configure.zcml:51
 msgid "Provides a human captcha widget based on a list of questions/answers."
 msgstr ""
 
-#: ./norobots_input.pt:3
+#: ./browser/norobots_macro.pt:32
+#: ./norobots_input.pt:6
 msgid "Question"
 msgstr "Otázka"
 
-#: ./browser/interfaces.py:10
+#: ./browser/interfaces.py:12
 msgid "Questions list (one per line). Example : 'What is 10 + 12 ?::22'. Answer can contain multiple values delimited by semicolon. Example : 'What is 5 + 5 ?::10;ten'."
 msgstr ""
 
-#: ./plone_forms/contact_info.py:77
+#: ./configure.zcml:60
+msgid "Removes the human usable captcha widget based on a list of questions/answers."
+msgstr ""
+
+#: ./plone_forms/contact_info.py:90
 msgid "Send"
 msgstr "Odeslat"
 
-#: ./plone_forms/contact_info.py:24
+#: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "Předmět"
 
-#: ./plone_forms/contact_info.py:127
-msgid "Unable to send mail: ${exception}"
-msgstr "Nepodařilo se odeslat email: ${exception}"
-
-#: ./browser/interfaces.py:15
-msgid "What is 10 + 4 ?"
-msgstr "Kolik je 10 + 4?"
-
-#: ./browser/interfaces.py:14
-msgid "What is 4 + 4 ?"
-msgstr "Kolik je 4+4 ?"
-
-#: ./browser/interfaces.py:16
-msgid "Write five cipher."
-msgstr """Zapište číslici "pět"."""
-
-#: ./validator.py:12
+#: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."
 msgstr "Nesprávná odpověď. Odpovězte prosím na další otázku."
 
@@ -119,7 +114,7 @@ msgstr "Nesprávná odpověď. Odpovězte prosím na další otázku."
 msgid "You entered an invalid email address."
 msgstr ""
 
-#: ./norobots_input.pt:7
+#: ./browser/norobots_macro.pt:37
+#: ./norobots_input.pt:14
 msgid "Your answer"
 msgstr "Vaše odpověď"
-

--- a/src/collective/z3cform/norobots/locales/cs/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/cs/LC_MESSAGES/collective.z3cform.norobots.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: nocaptcha\n"
-"POT-Creation-Date: 2020-06-24 07:33+0000\n"
+"POT-Creation-Date: 2020-06-24 08:09+0000\n"
 "PO-Revision-Date: 2010-10-09 12:32+0100\n"
 "Last-Translator: Radim Novotny <novotny.radim@gmail.com>\n"
 "Language-Team: Czech <info@dms4u.cz>\n"
@@ -105,6 +105,18 @@ msgstr "Odeslat"
 #: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "Předmět"
+
+#: Default question 3
+msgid "What is 10 + 4 ?"
+msgstr "Kolik je 10 + 4?"
+
+#: Default question 1
+msgid "What is 4 + 4 ?"
+msgstr "Kolik je 4+4 ?"
+
+#: Default question 2
+msgid "Write five cipher."
+msgstr """Zapište číslici "pět"."""
 
 #: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."

--- a/src/collective/z3cform/norobots/locales/da/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/da/LC_MESSAGES/collective.z3cform.norobots.po
@@ -1,11 +1,11 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.z3cform.norobots\n"
-"POT-Creation-Date: 2013-04-09 10:58+0000\n"
+"POT-Creation-Date: 2020-06-24 07:33+0000\n"
 "PO-Revision-Date: 2011-03-25 12:56+0100\n"
 "Last-Translator: Thomas Clement Mogensen <tmog@headnet.dk>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,105 +18,100 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.z3cform.norobots\n"
 
-#: ./plone_forms/contact_info.py:32
+#: ./browser/norobots_macro.pt:18
+#: ./plone_forms/contact_info.py:43
 msgid "Are you a human ?"
 msgstr "Bekræft at du ikke er en robot"
 
-#: ./plone_forms/contact_info.py:42
+#: ./plone_forms/contact_info.py:55
 msgid "Contact form"
 msgstr "Kontaktformular"
 
-#: ./plone_forms/contact_info.py:19
+#: ./plone_forms/contact_info.py:24
 msgid "E-Mail"
 msgstr "E-mailadresse"
 
-#: ./plone_forms/contact_info.py:33
+#: ./browser/norobots_macro.pt:28
+#: ./plone_forms/contact_info.py:44
 msgid "In order to avoid spam, please answer the question below."
 msgstr "For at bekræfte du ikke er en robot, beder vi dig svare på nedenstående spørgsmål."
 
-#: ./plone_forms/contact_info.py:132
+#: ./plone_forms/contact_info.py:149
 msgid "Mail sent."
 msgstr "E-mail sendt."
 
-#: ./plone_forms/contact_info.py:28
+#: ./plone_forms/contact_info.py:37
 msgid "Message"
 msgstr "Besked"
 
-#: ./plone_forms/contact_info.py:15
+#: ./plone_forms/contact_info.py:20
 msgid "Name"
 msgstr "Navn"
 
-#: Profile title in configure.zcml
+#: ./configure.zcml:51
 msgid "Norobots captcha field (collective.z3cform.norobots)"
 msgstr ""
 
-#: ./browser/interfaces.py:9
+#: ./configure.zcml:60
+msgid "Norobots captcha field UNINSTALLATION"
+msgstr ""
+
+#: ./browser/interfaces.py:11
 msgid "Norobots question::answer"
 msgstr ""
 
-#: ./browser/controlpanel.py:17
+#: ./browser/controlpanel.py:19
 #: ./profiles/default/controlpanel.xml
 msgid "Norobots widget settings"
 msgstr ""
 
-#: ./plone_forms/contact_info.py:83
+#: ./plone_forms/contact_info.py:96
 msgid "Please correct the indicated errors and don't forget to fill in the field 'Are you a human ?'."
 msgstr "Vær venlig at rette markerede fejl"
 
-#: ./plone_forms/contact_info.py:29
+#: ./plone_forms/contact_info.py:38
 msgid "Please enter the message you want to send."
 msgstr "Indtast besked, du ønsker at sende"
 
-#: ./plone_forms/contact_info.py:25
+#: ./plone_forms/contact_info.py:32
 msgid "Please enter the subject of the message you want to send."
 msgstr "Indtast emne for meddelelse"
 
-#: ./plone_forms/contact_info.py:20
+#: ./plone_forms/contact_info.py:25
 msgid "Please enter your e-mail address."
 msgstr "Indtast e-mailadresse"
 
-#: ./plone_forms/contact_info.py:16
+#: ./plone_forms/contact_info.py:20
 msgid "Please enter your full name."
 msgstr "Indtast fuldt navn"
 
-#: Profile description in configure.zcml
+#: ./configure.zcml:51
 msgid "Provides a human captcha widget based on a list of questions/answers."
 msgstr ""
 
 #. Default: "Question"
-#: ./norobots_input.pt:3
+#: ./browser/norobots_macro.pt:32
+#: ./norobots_input.pt:6
 msgid "Question"
 msgstr "Spørgsmål"
 
-#: ./browser/interfaces.py:10
+#: ./browser/interfaces.py:12
 msgid "Questions list (one per line). Example : 'What is 10 + 12 ?::22'. Answer can contain multiple values delimited by semicolon. Example : 'What is 5 + 5 ?::10;ten'."
 msgstr ""
 
-#: ./plone_forms/contact_info.py:77
+#: ./configure.zcml:60
+msgid "Removes the human usable captcha widget based on a list of questions/answers."
+msgstr ""
+
+#: ./plone_forms/contact_info.py:90
 msgid "Send"
 msgstr "Send"
 
-#: ./plone_forms/contact_info.py:24
+#: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "Emne"
 
-#: ./plone_forms/contact_info.py:127
-msgid "Unable to send mail: ${exception}"
-msgstr "E-mail kunne ikke afsendes: ${exception}"
-
-#: ./browser/interfaces.py:15
-msgid "What is 10 + 4 ?"
-msgstr ""
-
-#: ./browser/interfaces.py:14
-msgid "What is 4 + 4 ?"
-msgstr ""
-
-#: ./browser/interfaces.py:16
-msgid "Write five cipher."
-msgstr ""
-
-#: ./validator.py:12
+#: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."
 msgstr "Det indtastede svar er desværre forkert. Besvar venligst det nye spørgsmål herunder."
 
@@ -125,7 +120,7 @@ msgid "You entered an invalid email address."
 msgstr "You entered an invalid email address"
 
 #. Default: "Your answer"
-#: ./norobots_input.pt:7
+#: ./browser/norobots_macro.pt:37
+#: ./norobots_input.pt:14
 msgid "Your answer"
 msgstr "Dit svar"
-

--- a/src/collective/z3cform/norobots/locales/da/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/da/LC_MESSAGES/collective.z3cform.norobots.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.z3cform.norobots\n"
-"POT-Creation-Date: 2020-06-24 07:33+0000\n"
+"POT-Creation-Date: 2020-06-24 08:09+0000\n"
 "PO-Revision-Date: 2011-03-25 12:56+0100\n"
 "Last-Translator: Thomas Clement Mogensen <tmog@headnet.dk>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -110,6 +110,18 @@ msgstr "Send"
 #: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "Emne"
+
+#: Default question 3
+msgid "What is 10 + 4 ?"
+msgstr ""
+
+#: Default question 1
+msgid "What is 4 + 4 ?"
+msgstr ""
+
+#: Default question 2
+msgid "Write five cipher."
+msgstr ""
 
 #: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."

--- a/src/collective/z3cform/norobots/locales/de/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/de/LC_MESSAGES/collective.z3cform.norobots.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.z3cform.norobots\n"
-"POT-Creation-Date: 2013-04-09 10:58+0000\n"
+"POT-Creation-Date: 2020-06-24 07:33+0000\n"
 "PO-Revision-Date: 2010-11-05 08:13+0100\n"
 "Last-Translator: Peter Mathis <peter.mathis@kombinat.at>\n"
 "Language-Team: petschki @ kombinat <peter.mathis@kombinat.at>\n"
@@ -16,104 +16,99 @@ msgstr ""
 "X-Poedit-Language: German\n"
 "X-Poedit-Country: Austria\n"
 
-#: ./plone_forms/contact_info.py:32
+#: ./browser/norobots_macro.pt:18
+#: ./plone_forms/contact_info.py:43
 msgid "Are you a human ?"
 msgstr "Sind Sie ein Mensch?"
 
-#: ./plone_forms/contact_info.py:42
+#: ./plone_forms/contact_info.py:55
 msgid "Contact form"
 msgstr "Kontaktformular"
 
-#: ./plone_forms/contact_info.py:19
+#: ./plone_forms/contact_info.py:24
 msgid "E-Mail"
 msgstr "E-Mail"
 
-#: ./plone_forms/contact_info.py:33
+#: ./browser/norobots_macro.pt:28
+#: ./plone_forms/contact_info.py:44
 msgid "In order to avoid spam, please answer the question below."
 msgstr "Beantworten Sie folgende Frage um Spam zu vermeiden."
 
-#: ./plone_forms/contact_info.py:132
+#: ./plone_forms/contact_info.py:149
 msgid "Mail sent."
 msgstr "E-Mail versendet"
 
-#: ./plone_forms/contact_info.py:28
+#: ./plone_forms/contact_info.py:37
 msgid "Message"
 msgstr "Nachricht"
 
-#: ./plone_forms/contact_info.py:15
+#: ./plone_forms/contact_info.py:20
 msgid "Name"
 msgstr "Name"
 
-#: Profile title in configure.zcml
+#: ./configure.zcml:51
 msgid "Norobots captcha field (collective.z3cform.norobots)"
 msgstr ""
 
-#: ./browser/interfaces.py:9
+#: ./configure.zcml:60
+msgid "Norobots captcha field UNINSTALLATION"
+msgstr ""
+
+#: ./browser/interfaces.py:11
 msgid "Norobots question::answer"
 msgstr ""
 
-#: ./browser/controlpanel.py:17
+#: ./browser/controlpanel.py:19
 #: ./profiles/default/controlpanel.xml
 msgid "Norobots widget settings"
 msgstr ""
 
-#: ./plone_forms/contact_info.py:83
+#: ./plone_forms/contact_info.py:96
 msgid "Please correct the indicated errors and don't forget to fill in the field 'Are you a human ?'."
 msgstr """Fehler bei der Eingabe. Prüfen Sie die Felder und geben Sie die richtige Antwort im Feld "Sind Sie ein Mensch?" an"""
 
-#: ./plone_forms/contact_info.py:29
+#: ./plone_forms/contact_info.py:38
 msgid "Please enter the message you want to send."
 msgstr "Geben Sie Ihre Nachricht ein"
 
-#: ./plone_forms/contact_info.py:25
+#: ./plone_forms/contact_info.py:32
 msgid "Please enter the subject of the message you want to send."
 msgstr "Geben Sie einen Betreff für Ihre Nachricht an"
 
-#: ./plone_forms/contact_info.py:20
+#: ./plone_forms/contact_info.py:25
 msgid "Please enter your e-mail address."
 msgstr "Geben Sie Ihre E-Mail Adresse an"
 
-#: ./plone_forms/contact_info.py:16
+#: ./plone_forms/contact_info.py:20
 msgid "Please enter your full name."
 msgstr "Geben Sie Ihren vollständigen Namen an"
 
-#: Profile description in configure.zcml
+#: ./configure.zcml:51
 msgid "Provides a human captcha widget based on a list of questions/answers."
 msgstr ""
 
-#: ./norobots_input.pt:3
+#: ./browser/norobots_macro.pt:32
+#: ./norobots_input.pt:6
 msgid "Question"
 msgstr "Frage"
 
-#: ./browser/interfaces.py:10
+#: ./browser/interfaces.py:12
 msgid "Questions list (one per line). Example : 'What is 10 + 12 ?::22'. Answer can contain multiple values delimited by semicolon. Example : 'What is 5 + 5 ?::10;ten'."
 msgstr ""
 
-#: ./plone_forms/contact_info.py:77
+#: ./configure.zcml:60
+msgid "Removes the human usable captcha widget based on a list of questions/answers."
+msgstr ""
+
+#: ./plone_forms/contact_info.py:90
 msgid "Send"
 msgstr "Senden"
 
-#: ./plone_forms/contact_info.py:24
+#: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "Betreff"
 
-#: ./plone_forms/contact_info.py:127
-msgid "Unable to send mail: ${exception}"
-msgstr "E-Mail konnte nicht versendet werden: ${exception}"
-
-#: ./browser/interfaces.py:15
-msgid "What is 10 + 4 ?"
-msgstr "Wieviel ist 10 + 4?"
-
-#: ./browser/interfaces.py:14
-msgid "What is 4 + 4 ?"
-msgstr "Wieviel ist 4 + 4?"
-
-#: ./browser/interfaces.py:16
-msgid "Write five cipher."
-msgstr """Schreiben Sie die Zahl "5" """
-
-#: ./validator.py:12
+#: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."
 msgstr "Ihre Antwort war leider falsch, bitte beantworten Sie nachstehend die neue Frage."
 
@@ -121,7 +116,7 @@ msgstr "Ihre Antwort war leider falsch, bitte beantworten Sie nachstehend die ne
 msgid "You entered an invalid email address."
 msgstr ""
 
-#: ./norobots_input.pt:7
+#: ./browser/norobots_macro.pt:37
+#: ./norobots_input.pt:14
 msgid "Your answer"
 msgstr "Ergebnis"
-

--- a/src/collective/z3cform/norobots/locales/de/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/de/LC_MESSAGES/collective.z3cform.norobots.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.z3cform.norobots\n"
-"POT-Creation-Date: 2020-06-24 07:33+0000\n"
+"POT-Creation-Date: 2020-06-24 08:09+0000\n"
 "PO-Revision-Date: 2010-11-05 08:13+0100\n"
 "Last-Translator: Peter Mathis <peter.mathis@kombinat.at>\n"
 "Language-Team: petschki @ kombinat <peter.mathis@kombinat.at>\n"
@@ -107,6 +107,18 @@ msgstr "Senden"
 #: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "Betreff"
+
+#: Default question 3
+msgid "What is 10 + 4 ?"
+msgstr "Wieviel ist 10 + 4?"
+
+#: Default question 1
+msgid "What is 4 + 4 ?"
+msgstr "Wieviel ist 4 + 4?"
+
+#: Default question 2
+msgid "Write five cipher."
+msgstr """Schreiben Sie die Zahl "5" """
 
 #: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."

--- a/src/collective/z3cform/norobots/locales/en/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/en/LC_MESSAGES/collective.z3cform.norobots.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-06-24 07:33+0000\n"
+"POT-Creation-Date: 2020-06-24 08:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -107,6 +107,18 @@ msgstr ""
 
 #: ./plone_forms/contact_info.py:31
 msgid "Subject"
+msgstr ""
+
+#: Default question 3
+msgid "What is 10 + 4 ?"
+msgstr ""
+
+#: Default question 1
+msgid "What is 4 + 4 ?"
+msgstr ""
+
+#: Default question 2
+msgid "Write five cipher."
 msgstr ""
 
 #: ./validator.py:9

--- a/src/collective/z3cform/norobots/locales/en/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/en/LC_MESSAGES/collective.z3cform.norobots.po
@@ -1,0 +1,123 @@
+# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
+# SOME DESCRIPTIVE TITLE.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2020-06-24 07:33+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
+"Preferred-Encodings: utf-8 latin1\n"
+"Domain: collective.z3cform.norobots\n"
+
+#: ./browser/norobots_macro.pt:18
+#: ./plone_forms/contact_info.py:43
+msgid "Are you a human ?"
+msgstr ""
+
+#: ./plone_forms/contact_info.py:55
+msgid "Contact form"
+msgstr ""
+
+#: ./plone_forms/contact_info.py:24
+msgid "E-Mail"
+msgstr ""
+
+#: ./browser/norobots_macro.pt:28
+#: ./plone_forms/contact_info.py:44
+msgid "In order to avoid spam, please answer the question below."
+msgstr ""
+
+#: ./plone_forms/contact_info.py:149
+msgid "Mail sent."
+msgstr ""
+
+#: ./plone_forms/contact_info.py:37
+msgid "Message"
+msgstr ""
+
+#: ./plone_forms/contact_info.py:20
+msgid "Name"
+msgstr ""
+
+#: ./configure.zcml:51
+msgid "Norobots captcha field (collective.z3cform.norobots)"
+msgstr ""
+
+#: ./configure.zcml:60
+msgid "Norobots captcha field UNINSTALLATION"
+msgstr ""
+
+#: ./browser/interfaces.py:11
+msgid "Norobots question::answer"
+msgstr ""
+
+#: ./browser/controlpanel.py:19
+#: ./profiles/default/controlpanel.xml
+msgid "Norobots widget settings"
+msgstr ""
+
+#: ./plone_forms/contact_info.py:96
+msgid "Please correct the indicated errors and don't forget to fill in the field 'Are you a human ?'."
+msgstr ""
+
+#: ./plone_forms/contact_info.py:38
+msgid "Please enter the message you want to send."
+msgstr ""
+
+#: ./plone_forms/contact_info.py:32
+msgid "Please enter the subject of the message you want to send."
+msgstr ""
+
+#: ./plone_forms/contact_info.py:25
+msgid "Please enter your e-mail address."
+msgstr ""
+
+#: ./plone_forms/contact_info.py:20
+msgid "Please enter your full name."
+msgstr ""
+
+#: ./configure.zcml:51
+msgid "Provides a human captcha widget based on a list of questions/answers."
+msgstr ""
+
+#: ./browser/norobots_macro.pt:32
+#: ./norobots_input.pt:6
+msgid "Question"
+msgstr ""
+
+#: ./browser/interfaces.py:12
+msgid "Questions list (one per line). Example : 'What is 10 + 12 ?::22'. Answer can contain multiple values delimited by semicolon. Example : 'What is 5 + 5 ?::10;ten'."
+msgstr ""
+
+#: ./configure.zcml:60
+msgid "Removes the human usable captcha widget based on a list of questions/answers."
+msgstr ""
+
+#: ./plone_forms/contact_info.py:90
+msgid "Send"
+msgstr ""
+
+#: ./plone_forms/contact_info.py:31
+msgid "Subject"
+msgstr ""
+
+#: ./validator.py:9
+msgid "You entered a wrong answer, please answer the new question below."
+msgstr ""
+
+#: ./plone_forms/constraints.py:10
+msgid "You entered an invalid email address."
+msgstr ""
+
+#: ./browser/norobots_macro.pt:37
+#: ./norobots_input.pt:14
+msgid "Your answer"
+msgstr ""

--- a/src/collective/z3cform/norobots/locales/es/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/es/LC_MESSAGES/collective.z3cform.norobots.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.z3cform.norobots\n"
-"POT-Creation-Date: 2013-04-09 10:58+0000\n"
+"POT-Creation-Date: 2020-06-24 07:33+0000\n"
 "PO-Revision-Date: 2012-07-12 12:43+0100\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: es <es@li.org>\n"
@@ -18,104 +18,99 @@ msgstr ""
 "Domain: collective.z3cform.norobots\n"
 "X-Poedit-Language: Spanish\n"
 
-#: ./plone_forms/contact_info.py:32
+#: ./browser/norobots_macro.pt:18
+#: ./plone_forms/contact_info.py:43
 msgid "Are you a human ?"
 msgstr "¿Es humano?"
 
-#: ./plone_forms/contact_info.py:42
+#: ./plone_forms/contact_info.py:55
 msgid "Contact form"
 msgstr "Formulario de contacto"
 
-#: ./plone_forms/contact_info.py:19
+#: ./plone_forms/contact_info.py:24
 msgid "E-Mail"
 msgstr "E-mail"
 
-#: ./plone_forms/contact_info.py:33
+#: ./browser/norobots_macro.pt:28
+#: ./plone_forms/contact_info.py:44
 msgid "In order to avoid spam, please answer the question below."
 msgstr "Para evitar el spam, responda a la siguiente pregunta por favor."
 
-#: ./plone_forms/contact_info.py:132
+#: ./plone_forms/contact_info.py:149
 msgid "Mail sent."
 msgstr "Mensaje enviado."
 
-#: ./plone_forms/contact_info.py:28
+#: ./plone_forms/contact_info.py:37
 msgid "Message"
 msgstr "Mensaje"
 
-#: ./plone_forms/contact_info.py:15
+#: ./plone_forms/contact_info.py:20
 msgid "Name"
 msgstr "Nombre"
 
-#: Profile title in configure.zcml
+#: ./configure.zcml:51
 msgid "Norobots captcha field (collective.z3cform.norobots)"
 msgstr ""
 
-#: ./browser/interfaces.py:9
+#: ./configure.zcml:60
+msgid "Norobots captcha field UNINSTALLATION"
+msgstr ""
+
+#: ./browser/interfaces.py:11
 msgid "Norobots question::answer"
 msgstr "Pregunta::respuesta"
 
-#: ./browser/controlpanel.py:17
+#: ./browser/controlpanel.py:19
 #: ./profiles/default/controlpanel.xml
 msgid "Norobots widget settings"
 msgstr "Configuración del captcha Norobots"
 
-#: ./plone_forms/contact_info.py:83
+#: ./plone_forms/contact_info.py:96
 msgid "Please correct the indicated errors and don't forget to fill in the field 'Are you a human ?'."
 msgstr "Corrija los errores indicados y no olvide rellenar el campo '¿Es humano?'"
 
-#: ./plone_forms/contact_info.py:29
+#: ./plone_forms/contact_info.py:38
 msgid "Please enter the message you want to send."
 msgstr "Introduzca el mensaje que desea enviar."
 
-#: ./plone_forms/contact_info.py:25
+#: ./plone_forms/contact_info.py:32
 msgid "Please enter the subject of the message you want to send."
 msgstr "Introduzca el asunto del mensaje que desea enviar."
 
-#: ./plone_forms/contact_info.py:20
+#: ./plone_forms/contact_info.py:25
 msgid "Please enter your e-mail address."
 msgstr "Introduzca su dirección de correo electrónico."
 
-#: ./plone_forms/contact_info.py:16
+#: ./plone_forms/contact_info.py:20
 msgid "Please enter your full name."
 msgstr "Introduzca su nombre."
 
-#: Profile description in configure.zcml
+#: ./configure.zcml:51
 msgid "Provides a human captcha widget based on a list of questions/answers."
 msgstr ""
 
-#: ./norobots_input.pt:3
+#: ./browser/norobots_macro.pt:32
+#: ./norobots_input.pt:6
 msgid "Question"
 msgstr "Pregunta"
 
-#: ./browser/interfaces.py:10
+#: ./browser/interfaces.py:12
 msgid "Questions list (one per line). Example : 'What is 10 + 12 ?::22'. Answer can contain multiple values delimited by semicolon. Example : 'What is 5 + 5 ?::10;ten'."
 msgstr "Lista de preguntas (una por línea). P.ej.: '¿Cuánto es 10 + 12?::22'. La respuesta puede contener varios valores separados por punto y coma. P.ej.: '¿Cuánto es 5 + 5?::10; diez'."
 
-#: ./plone_forms/contact_info.py:77
+#: ./configure.zcml:60
+msgid "Removes the human usable captcha widget based on a list of questions/answers."
+msgstr ""
+
+#: ./plone_forms/contact_info.py:90
 msgid "Send"
 msgstr "Enviar"
 
-#: ./plone_forms/contact_info.py:24
+#: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "Asunto"
 
-#: ./plone_forms/contact_info.py:127
-msgid "Unable to send mail: ${exception}"
-msgstr "No ha sido posible enviar el mensaje: ${exception}"
-
-#: ./browser/interfaces.py:15
-msgid "What is 10 + 4 ?"
-msgstr "¿Cuánto es 10 + 4?"
-
-#: ./browser/interfaces.py:14
-msgid "What is 4 + 4 ?"
-msgstr "¿Cuánto es 4 + 4?"
-
-#: ./browser/interfaces.py:16
-msgid "Write five cipher."
-msgstr "Escriba cinco utilizando números."
-
-#: ./validator.py:12
+#: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."
 msgstr "Ha introducido una respuesta incorrecta, responda a la siguiente pregunta por favor."
 
@@ -123,7 +118,7 @@ msgstr "Ha introducido una respuesta incorrecta, responda a la siguiente pregunt
 msgid "You entered an invalid email address."
 msgstr "Ha introducido una dirección de correo electrónico no válida."
 
-#: ./norobots_input.pt:7
+#: ./browser/norobots_macro.pt:37
+#: ./norobots_input.pt:14
 msgid "Your answer"
 msgstr "Su respuesta"
-

--- a/src/collective/z3cform/norobots/locales/es/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/es/LC_MESSAGES/collective.z3cform.norobots.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.z3cform.norobots\n"
-"POT-Creation-Date: 2020-06-24 07:33+0000\n"
+"POT-Creation-Date: 2020-06-24 08:09+0000\n"
 "PO-Revision-Date: 2012-07-12 12:43+0100\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: es <es@li.org>\n"
@@ -109,6 +109,18 @@ msgstr "Enviar"
 #: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "Asunto"
+
+#: Default question 3
+msgid "What is 10 + 4 ?"
+msgstr "¿Cuánto es 10 + 4?"
+
+#: Default question 1
+msgid "What is 4 + 4 ?"
+msgstr "¿Cuánto es 4 + 4?"
+
+#: Default question 2
+msgid "Write five cipher."
+msgstr "Escriba cinco utilizando números."
 
 #: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."

--- a/src/collective/z3cform/norobots/locales/eu/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/eu/LC_MESSAGES/collective.z3cform.norobots.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.z3cform.norobots\n"
-"POT-Creation-Date: 2020-06-24 07:33+0000\n"
+"POT-Creation-Date: 2020-06-24 08:09+0000\n"
 "PO-Revision-Date: 2012-07-12 12:22+0100\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: eu <eu@li.org>\n"
@@ -106,6 +106,18 @@ msgstr "Bidali"
 #: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "Gaia"
+
+#: Default question 3
+msgid "What is 10 + 4 ?"
+msgstr "Zenbat da 10+4?"
+
+#: Default question 1
+msgid "What is 4 + 4 ?"
+msgstr "Zenbat da 4+4?"
+
+#: Default question 2
+msgid "Write five cipher."
+msgstr "Idatzi 'bost' zenbakiak erabiliz."
 
 #: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."

--- a/src/collective/z3cform/norobots/locales/eu/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/eu/LC_MESSAGES/collective.z3cform.norobots.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.z3cform.norobots\n"
-"POT-Creation-Date: 2013-04-09 10:58+0000\n"
+"POT-Creation-Date: 2020-06-24 07:33+0000\n"
 "PO-Revision-Date: 2012-07-12 12:22+0100\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: eu <eu@li.org>\n"
@@ -15,104 +15,99 @@ msgstr ""
 "Domain: collective.z3cform.norobots\n"
 "X-Poedit-Language: Basque\n"
 
-#: ./plone_forms/contact_info.py:32
+#: ./browser/norobots_macro.pt:18
+#: ./plone_forms/contact_info.py:43
 msgid "Are you a human ?"
 msgstr "Gizakia zara?"
 
-#: ./plone_forms/contact_info.py:42
+#: ./plone_forms/contact_info.py:55
 msgid "Contact form"
 msgstr "Kontaktu formularioa"
 
-#: ./plone_forms/contact_info.py:19
+#: ./plone_forms/contact_info.py:24
 msgid "E-Mail"
 msgstr "E-posta"
 
-#: ./plone_forms/contact_info.py:33
+#: ./browser/norobots_macro.pt:28
+#: ./plone_forms/contact_info.py:44
 msgid "In order to avoid spam, please answer the question below."
 msgstr "Spama ekiditeko metodoa da hau, erantzun beheko galderari mesedez."
 
-#: ./plone_forms/contact_info.py:132
+#: ./plone_forms/contact_info.py:149
 msgid "Mail sent."
 msgstr "Mezua ondo bidali da"
 
-#: ./plone_forms/contact_info.py:28
+#: ./plone_forms/contact_info.py:37
 msgid "Message"
 msgstr "Mezua"
 
-#: ./plone_forms/contact_info.py:15
+#: ./plone_forms/contact_info.py:20
 msgid "Name"
 msgstr "Izena"
 
-#: Profile title in configure.zcml
+#: ./configure.zcml:51
 msgid "Norobots captcha field (collective.z3cform.norobots)"
 msgstr ""
 
-#: ./browser/interfaces.py:9
+#: ./configure.zcml:60
+msgid "Norobots captcha field UNINSTALLATION"
+msgstr ""
+
+#: ./browser/interfaces.py:11
 msgid "Norobots question::answer"
 msgstr "Galdera::erantzuna"
 
-#: ./browser/controlpanel.py:17
+#: ./browser/controlpanel.py:19
 #: ./profiles/default/controlpanel.xml
 msgid "Norobots widget settings"
 msgstr "Norobots captcha sistemaren konfigurazioa"
 
-#: ./plone_forms/contact_info.py:83
+#: ./plone_forms/contact_info.py:96
 msgid "Please correct the indicated errors and don't forget to fill in the field 'Are you a human ?'."
 msgstr "Zuzendu adierazten diren erroreak eta ez ahaztu 'Gizakia zara?' galderari erantzutea."
 
-#: ./plone_forms/contact_info.py:29
+#: ./plone_forms/contact_info.py:38
 msgid "Please enter the message you want to send."
 msgstr "Bidali beharrekoa"
 
-#: ./plone_forms/contact_info.py:25
+#: ./plone_forms/contact_info.py:32
 msgid "Please enter the subject of the message you want to send."
 msgstr "Bidali nahi duzun mezuaren gaia idatzi"
 
-#: ./plone_forms/contact_info.py:20
+#: ./plone_forms/contact_info.py:25
 msgid "Please enter your e-mail address."
 msgstr "Idatzi zure e-posta"
 
-#: ./plone_forms/contact_info.py:16
+#: ./plone_forms/contact_info.py:20
 msgid "Please enter your full name."
 msgstr "Idatzi zure izena"
 
-#: Profile description in configure.zcml
+#: ./configure.zcml:51
 msgid "Provides a human captcha widget based on a list of questions/answers."
 msgstr ""
 
-#: ./norobots_input.pt:3
+#: ./browser/norobots_macro.pt:32
+#: ./norobots_input.pt:6
 msgid "Question"
 msgstr "Galdera"
 
-#: ./browser/interfaces.py:10
+#: ./browser/interfaces.py:12
 msgid "Questions list (one per line). Example : 'What is 10 + 12 ?::22'. Answer can contain multiple values delimited by semicolon. Example : 'What is 5 + 5 ?::10;ten'."
 msgstr "Galderak (bat lerro bakoitzean). Adibidez: 'Zenbat da 10 + 12?:22'. Erantzunak balio bat baino gehiago izan dezake, puntu eta koma karakterearekin banatuta. Adibidez: 'Zenbat da 5 + 5?::10;hamar'."
 
-#: ./plone_forms/contact_info.py:77
+#: ./configure.zcml:60
+msgid "Removes the human usable captcha widget based on a list of questions/answers."
+msgstr ""
+
+#: ./plone_forms/contact_info.py:90
 msgid "Send"
 msgstr "Bidali"
 
-#: ./plone_forms/contact_info.py:24
+#: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "Gaia"
 
-#: ./plone_forms/contact_info.py:127
-msgid "Unable to send mail: ${exception}"
-msgstr "Ezin izan da mezua bidali: ${exception}"
-
-#: ./browser/interfaces.py:15
-msgid "What is 10 + 4 ?"
-msgstr "Zenbat da 10+4?"
-
-#: ./browser/interfaces.py:14
-msgid "What is 4 + 4 ?"
-msgstr "Zenbat da 4+4?"
-
-#: ./browser/interfaces.py:16
-msgid "Write five cipher."
-msgstr "Idatzi 'bost' zenbakiak erabiliz."
-
-#: ./validator.py:12
+#: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."
 msgstr "Okerreko erantzuna eman duzu. "
 
@@ -120,7 +115,7 @@ msgstr "Okerreko erantzuna eman duzu. "
 msgid "You entered an invalid email address."
 msgstr "E-posta helbidea ez da zuzena"
 
-#: ./norobots_input.pt:7
+#: ./browser/norobots_macro.pt:37
+#: ./norobots_input.pt:14
 msgid "Your answer"
 msgstr "Erantzuna"
-

--- a/src/collective/z3cform/norobots/locales/fi/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/fi/LC_MESSAGES/collective.z3cform.norobots.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: z 3cform\n"
-"POT-Creation-Date: 2020-06-24 07:33+0000\n"
+"POT-Creation-Date: 2020-06-24 08:09+0000\n"
 "PO-Revision-Date: 2010-09-14 13:15+0300\n"
 "Last-Translator: Petri Savolainen <>\n"
 "Language-Team: Finnish\n"
@@ -107,6 +107,18 @@ msgstr "Lähetä"
 #: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "Aihe"
+
+#: Default question 3
+msgid "What is 10 + 4 ?"
+msgstr "Paljonko on 10 + 4?"
+
+#: Default question 1
+msgid "What is 4 + 4 ?"
+msgstr "Paljonko on 4 + 4?"
+
+#: Default question 2
+msgid "Write five cipher."
+msgstr """Kirjoita "viisi" numerona."""
 
 #: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."

--- a/src/collective/z3cform/norobots/locales/fi/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/fi/LC_MESSAGES/collective.z3cform.norobots.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: z 3cform\n"
-"POT-Creation-Date: 2013-04-09 10:58+0000\n"
+"POT-Creation-Date: 2020-06-24 07:33+0000\n"
 "PO-Revision-Date: 2010-09-14 13:15+0300\n"
 "Last-Translator: Petri Savolainen <>\n"
 "Language-Team: Finnish\n"
@@ -16,104 +16,99 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.z3cform.norobots\n"
 
-#: ./plone_forms/contact_info.py:32
+#: ./browser/norobots_macro.pt:18
+#: ./plone_forms/contact_info.py:43
 msgid "Are you a human ?"
 msgstr "Varmistuskysymys"
 
-#: ./plone_forms/contact_info.py:42
+#: ./plone_forms/contact_info.py:55
 msgid "Contact form"
 msgstr "Yhteydenotto"
 
-#: ./plone_forms/contact_info.py:19
+#: ./plone_forms/contact_info.py:24
 msgid "E-Mail"
 msgstr "Sähköpostiosoite"
 
-#: ./plone_forms/contact_info.py:33
+#: ./browser/norobots_macro.pt:28
+#: ./plone_forms/contact_info.py:44
 msgid "In order to avoid spam, please answer the question below."
 msgstr "Olethan ihminen etkä roskapostitin? Varmistaaksemme asian, ole hyvä ja vastaa allaolevaan kysymykseen."
 
-#: ./plone_forms/contact_info.py:132
+#: ./plone_forms/contact_info.py:149
 msgid "Mail sent."
 msgstr "Viesti lähetetty"
 
-#: ./plone_forms/contact_info.py:28
+#: ./plone_forms/contact_info.py:37
 msgid "Message"
 msgstr "Viesti"
 
-#: ./plone_forms/contact_info.py:15
+#: ./plone_forms/contact_info.py:20
 msgid "Name"
 msgstr "Nimi"
 
-#: Profile title in configure.zcml
+#: ./configure.zcml:51
 msgid "Norobots captcha field (collective.z3cform.norobots)"
 msgstr ""
 
-#: ./browser/interfaces.py:9
+#: ./configure.zcml:60
+msgid "Norobots captcha field UNINSTALLATION"
+msgstr ""
+
+#: ./browser/interfaces.py:11
 msgid "Norobots question::answer"
 msgstr ""
 
-#: ./browser/controlpanel.py:17
+#: ./browser/controlpanel.py:19
 #: ./profiles/default/controlpanel.xml
 msgid "Norobots widget settings"
 msgstr ""
 
-#: ./plone_forms/contact_info.py:83
+#: ./plone_forms/contact_info.py:96
 msgid "Please correct the indicated errors and don't forget to fill in the field 'Are you a human ?'."
 msgstr "Ole hyvä ja korjaa osoitetut virheet. Muista myös vastata varmistuskysymykseen."
 
-#: ./plone_forms/contact_info.py:29
+#: ./plone_forms/contact_info.py:38
 msgid "Please enter the message you want to send."
 msgstr "Kirjoita sisältö viestille jonka haluat lähettää"
 
-#: ./plone_forms/contact_info.py:25
+#: ./plone_forms/contact_info.py:32
 msgid "Please enter the subject of the message you want to send."
 msgstr "Anna viestillesi otsikko"
 
-#: ./plone_forms/contact_info.py:20
+#: ./plone_forms/contact_info.py:25
 msgid "Please enter your e-mail address."
 msgstr "Ole hyvä ja anna sähköpostiosoitteesi."
 
-#: ./plone_forms/contact_info.py:16
+#: ./plone_forms/contact_info.py:20
 msgid "Please enter your full name."
 msgstr "Ole hyvä ja anna koko nimesi."
 
-#: Profile description in configure.zcml
+#: ./configure.zcml:51
 msgid "Provides a human captcha widget based on a list of questions/answers."
 msgstr ""
 
-#: ./norobots_input.pt:3
+#: ./browser/norobots_macro.pt:32
+#: ./norobots_input.pt:6
 msgid "Question"
 msgstr "Kysymys"
 
-#: ./browser/interfaces.py:10
+#: ./browser/interfaces.py:12
 msgid "Questions list (one per line). Example : 'What is 10 + 12 ?::22'. Answer can contain multiple values delimited by semicolon. Example : 'What is 5 + 5 ?::10;ten'."
 msgstr ""
 
-#: ./plone_forms/contact_info.py:77
+#: ./configure.zcml:60
+msgid "Removes the human usable captcha widget based on a list of questions/answers."
+msgstr ""
+
+#: ./plone_forms/contact_info.py:90
 msgid "Send"
 msgstr "Lähetä"
 
-#: ./plone_forms/contact_info.py:24
+#: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "Aihe"
 
-#: ./plone_forms/contact_info.py:127
-msgid "Unable to send mail: ${exception}"
-msgstr "Viestiä ei voitu lähettää: ${exception}"
-
-#: ./browser/interfaces.py:15
-msgid "What is 10 + 4 ?"
-msgstr "Paljonko on 10 + 4?"
-
-#: ./browser/interfaces.py:14
-msgid "What is 4 + 4 ?"
-msgstr "Paljonko on 4 + 4?"
-
-#: ./browser/interfaces.py:16
-msgid "Write five cipher."
-msgstr """Kirjoita "viisi" numerona."""
-
-#: ./validator.py:12
+#: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."
 msgstr "Vastauksesi oli virheellinen, ole hyvä ja yritä uudestaan."
 
@@ -121,7 +116,7 @@ msgstr "Vastauksesi oli virheellinen, ole hyvä ja yritä uudestaan."
 msgid "You entered an invalid email address."
 msgstr ""
 
-#: ./norobots_input.pt:7
+#: ./browser/norobots_macro.pt:37
+#: ./norobots_input.pt:14
 msgid "Your answer"
 msgstr "Vastauksesi"
-

--- a/src/collective/z3cform/norobots/locales/fr/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/fr/LC_MESSAGES/collective.z3cform.norobots.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.z3cform.norobots\n"
-"POT-Creation-Date: 2013-04-09 10:58+0000\n"
+"POT-Creation-Date: 2020-06-24 07:33+0000\n"
 "PO-Revision-Date: 2010-01-11 14:51+0200\n"
 "Last-Translator: Sylvain Boureliou <sylvain.boureliou@makina-corpus.com>\n"
 "Language-Team: French\n"
@@ -17,104 +17,99 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.z3cform.norobots\n"
 
-#: ./plone_forms/contact_info.py:32
+#: ./browser/norobots_macro.pt:18
+#: ./plone_forms/contact_info.py:43
 msgid "Are you a human ?"
 msgstr "Etes-vous un être humain ?"
 
-#: ./plone_forms/contact_info.py:42
+#: ./plone_forms/contact_info.py:55
 msgid "Contact form"
 msgstr "Formulaire de contact"
 
-#: ./plone_forms/contact_info.py:19
+#: ./plone_forms/contact_info.py:24
 msgid "E-Mail"
 msgstr "Courriel"
 
-#: ./plone_forms/contact_info.py:33
+#: ./browser/norobots_macro.pt:28
+#: ./plone_forms/contact_info.py:44
 msgid "In order to avoid spam, please answer the question below."
 msgstr "Dans le but d'éviter l'envoi de spams, merci de répondre à la question ci-dessous."
 
-#: ./plone_forms/contact_info.py:132
+#: ./plone_forms/contact_info.py:149
 msgid "Mail sent."
 msgstr "Courriel envoyé"
 
-#: ./plone_forms/contact_info.py:28
+#: ./plone_forms/contact_info.py:37
 msgid "Message"
 msgstr "Message"
 
-#: ./plone_forms/contact_info.py:15
+#: ./plone_forms/contact_info.py:20
 msgid "Name"
 msgstr "Nom"
 
-#: Profile title in configure.zcml
+#: ./configure.zcml:51
 msgid "Norobots captcha field (collective.z3cform.norobots)"
 msgstr "Champ captcha Norobots (collective.z3cform.norobots)"
 
-#: ./browser/interfaces.py:9
+#: ./configure.zcml:60
+msgid "Norobots captcha field UNINSTALLATION"
+msgstr ""
+
+#: ./browser/interfaces.py:11
 msgid "Norobots question::answer"
 msgstr "Questions/réponses"
 
-#: ./browser/controlpanel.py:17
+#: ./browser/controlpanel.py:19
 #: ./profiles/default/controlpanel.xml
 msgid "Norobots widget settings"
 msgstr "Captcha Norobots"
 
-#: ./plone_forms/contact_info.py:83
+#: ./plone_forms/contact_info.py:96
 msgid "Please correct the indicated errors and don't forget to fill in the field 'Are you a human ?'."
 msgstr """Merci de corriger les erreurs indiquées et n'oubliez pas de remplir le champ "Etes-vous un être humain ?"."""
 
-#: ./plone_forms/contact_info.py:29
+#: ./plone_forms/contact_info.py:38
 msgid "Please enter the message you want to send."
 msgstr "Veuillez saisir le message que vous souhaitez envoyer."
 
-#: ./plone_forms/contact_info.py:25
+#: ./plone_forms/contact_info.py:32
 msgid "Please enter the subject of the message you want to send."
 msgstr "Veuillez saisir le sujet du courrier électronique que vous souhaitez envoyer."
 
-#: ./plone_forms/contact_info.py:20
+#: ./plone_forms/contact_info.py:25
 msgid "Please enter your e-mail address."
 msgstr "Veuillez saisir votre adresse courriel."
 
-#: ./plone_forms/contact_info.py:16
+#: ./plone_forms/contact_info.py:20
 msgid "Please enter your full name."
 msgstr "Veuillez saisir votre nom complet."
 
-#: Profile description in configure.zcml
+#: ./configure.zcml:51
 msgid "Provides a human captcha widget based on a list of questions/answers."
 msgstr ""
 
-#: ./norobots_input.pt:3
+#: ./browser/norobots_macro.pt:32
+#: ./norobots_input.pt:6
 msgid "Question"
 msgstr "Question"
 
-#: ./browser/interfaces.py:10
+#: ./browser/interfaces.py:12
 msgid "Questions list (one per line). Example : 'What is 10 + 12 ?::22'. Answer can contain multiple values delimited by semicolon. Example : 'What is 5 + 5 ?::10;ten'."
 msgstr """Liste de questions (une par ligne). Exemple : "Combien font 10 + 12 ?::22". Une réponse peut contenir plusieurs valeurs séparées par des point-virgules. Exemple : "Combien font 5 + 5 ?::10;dix"."""
 
-#: ./plone_forms/contact_info.py:77
+#: ./configure.zcml:60
+msgid "Removes the human usable captcha widget based on a list of questions/answers."
+msgstr ""
+
+#: ./plone_forms/contact_info.py:90
 msgid "Send"
 msgstr "Envoyer"
 
-#: ./plone_forms/contact_info.py:24
+#: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "Sujet"
 
-#: ./plone_forms/contact_info.py:127
-msgid "Unable to send mail: ${exception}"
-msgstr "Impossible d'envoyer un courriel : ${exception}"
-
-#: ./browser/interfaces.py:15
-msgid "What is 10 + 4 ?"
-msgstr "Combien font 10 + 4 ?"
-
-#: ./browser/interfaces.py:14
-msgid "What is 4 + 4 ?"
-msgstr "Combien font 4 + 4 ?"
-
-#: ./browser/interfaces.py:16
-msgid "Write five cipher."
-msgstr """Écrire "5" en chiffre"""
-
-#: ./validator.py:12
+#: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."
 msgstr "Vous avez entré une réponse fausse, merci de répondre à la nouvelle question ci-dessous."
 
@@ -122,7 +117,7 @@ msgstr "Vous avez entré une réponse fausse, merci de répondre à la nouvelle 
 msgid "You entered an invalid email address."
 msgstr "Vous avez entré une adresse e-mail invalide."
 
-#: ./norobots_input.pt:7
+#: ./browser/norobots_macro.pt:37
+#: ./norobots_input.pt:14
 msgid "Your answer"
 msgstr "Votre réponse"
-

--- a/src/collective/z3cform/norobots/locales/fr/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/fr/LC_MESSAGES/collective.z3cform.norobots.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.z3cform.norobots\n"
-"POT-Creation-Date: 2020-06-24 07:33+0000\n"
+"POT-Creation-Date: 2020-06-24 08:09+0000\n"
 "PO-Revision-Date: 2010-01-11 14:51+0200\n"
 "Last-Translator: Sylvain Boureliou <sylvain.boureliou@makina-corpus.com>\n"
 "Language-Team: French\n"
@@ -108,6 +108,18 @@ msgstr "Envoyer"
 #: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "Sujet"
+
+#: Default question 3
+msgid "What is 10 + 4 ?"
+msgstr "Combien font 10 + 4 ?"
+
+#: Default question 1
+msgid "What is 4 + 4 ?"
+msgstr "Combien font 4 + 4 ?"
+
+#: Default question 2
+msgid "Write five cipher."
+msgstr """Écrire "5" en chiffre"""
 
 #: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."

--- a/src/collective/z3cform/norobots/locales/it/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/it/LC_MESSAGES/collective.z3cform.norobots.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-06-24 07:33+0000\n"
+"POT-Creation-Date: 2020-06-24 08:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Luca Fabbri <keul@redturtle.it>\n"
 "Language-Team: RedTurtle Technology <sviluppoplone@redturtle.it>\n"
@@ -108,6 +108,18 @@ msgstr "Invia"
 #: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "Oggetto"
+
+#: Default question 3
+msgid "What is 10 + 4 ?"
+msgstr "Quanto fa 10 + 4 ?"
+
+#: Default question 1
+msgid "What is 4 + 4 ?"
+msgstr "Quanto fa 4 + 4 ?"
+
+#: Default question 2
+msgid "Write five cipher."
+msgstr "Scrivi cinque in cifre."
 
 #: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."

--- a/src/collective/z3cform/norobots/locales/it/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/it/LC_MESSAGES/collective.z3cform.norobots.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-04-09 10:58+0000\n"
+"POT-Creation-Date: 2020-06-24 07:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Luca Fabbri <keul@redturtle.it>\n"
 "Language-Team: RedTurtle Technology <sviluppoplone@redturtle.it>\n"
@@ -15,106 +15,101 @@ msgstr ""
 "Language-Code: it\n"
 "Language-Name: Italian\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: collective.pfg.norobots\n"
+"Domain: collective.z3cform.norobots\n"
 
-#: ./plone_forms/contact_info.py:32
+#: ./browser/norobots_macro.pt:18
+#: ./plone_forms/contact_info.py:43
 msgid "Are you a human ?"
 msgstr "Sei un umano ?"
 
-#: ./plone_forms/contact_info.py:42
+#: ./plone_forms/contact_info.py:55
 msgid "Contact form"
 msgstr "Modulo di contatto"
 
-#: ./plone_forms/contact_info.py:19
+#: ./plone_forms/contact_info.py:24
 msgid "E-Mail"
 msgstr ""
 
-#: ./plone_forms/contact_info.py:33
+#: ./browser/norobots_macro.pt:28
+#: ./plone_forms/contact_info.py:44
 msgid "In order to avoid spam, please answer the question below."
 msgstr "Per prevenire lo spam, prego rispondi alla domanda seguente."
 
-#: ./plone_forms/contact_info.py:132
+#: ./plone_forms/contact_info.py:149
 msgid "Mail sent."
 msgstr "Messaggio inviato"
 
-#: ./plone_forms/contact_info.py:28
+#: ./plone_forms/contact_info.py:37
 msgid "Message"
 msgstr "Messaggio"
 
-#: ./plone_forms/contact_info.py:15
+#: ./plone_forms/contact_info.py:20
 msgid "Name"
 msgstr "Nome"
 
-#: Profile title in configure.zcml
+#: ./configure.zcml:51
 msgid "Norobots captcha field (collective.z3cform.norobots)"
 msgstr "Campo captcha Norobots (collective.z3cform.norobots)"
 
-#: ./browser/interfaces.py:9
+#: ./configure.zcml:60
+msgid "Norobots captcha field UNINSTALLATION"
+msgstr ""
+
+#: ./browser/interfaces.py:11
 msgid "Norobots question::answer"
 msgstr "Norobots domanda::risposta"
 
-#: ./browser/controlpanel.py:17
+#: ./browser/controlpanel.py:19
 #: ./profiles/default/controlpanel.xml
 msgid "Norobots widget settings"
 msgstr "Impostazioni widget Norobots"
 
-#: ./plone_forms/contact_info.py:83
+#: ./plone_forms/contact_info.py:96
 msgid "Please correct the indicated errors and don't forget to fill in the field 'Are you a human ?'."
 msgstr "Prego correggi gli errori indicati e non dimenticare di compilare il campo 'Sei un umano ?'"
 
-#: ./plone_forms/contact_info.py:29
+#: ./plone_forms/contact_info.py:38
 msgid "Please enter the message you want to send."
 msgstr "Prego inserire il messaggio che vuoi inviare."
 
-#: ./plone_forms/contact_info.py:25
+#: ./plone_forms/contact_info.py:32
 msgid "Please enter the subject of the message you want to send."
 msgstr "Prego inserire l'oggetto del messaggio che vuoi inviare."
 
-#: ./plone_forms/contact_info.py:20
+#: ./plone_forms/contact_info.py:25
 msgid "Please enter your e-mail address."
 msgstr "Prego inserisci il tuo indirizzo e-mail."
 
-#: ./plone_forms/contact_info.py:16
+#: ./plone_forms/contact_info.py:20
 msgid "Please enter your full name."
 msgstr "Prego inserisci il tuo nome completo"
 
-#: Profile description in configure.zcml
+#: ./configure.zcml:51
 msgid "Provides a human captcha widget based on a list of questions/answers."
 msgstr "Fornisce un campo captcha basato su una lista di domande/risposte."
 
-#: ./norobots_input.pt:3
+#: ./browser/norobots_macro.pt:32
+#: ./norobots_input.pt:6
 msgid "Question"
 msgstr "Domanda"
 
-#: ./browser/interfaces.py:10
+#: ./browser/interfaces.py:12
 msgid "Questions list (one per line). Example : 'What is 10 + 12 ?::22'. Answer can contain multiple values delimited by semicolon. Example : 'What is 5 + 5 ?::10;ten'."
 msgstr "Lista delle domande (una per riga). Esempio : 'Quanto fa 10 + 12 ?::22'. Le risposte possono essere più di una, deliminate dal punto-e-virgola. Esempio : 'Quanto fa 5 + 5 ?::10;dieci'."
 
-#: ./plone_forms/contact_info.py:77
+#: ./configure.zcml:60
+msgid "Removes the human usable captcha widget based on a list of questions/answers."
+msgstr ""
+
+#: ./plone_forms/contact_info.py:90
 msgid "Send"
 msgstr "Invia"
 
-#: ./plone_forms/contact_info.py:24
+#: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "Oggetto"
 
-#: ./plone_forms/contact_info.py:127
-msgid "Unable to send mail: ${exception}"
-msgstr "Impossibile inviare l'e-mail: ${exception}"
-
-#: ./browser/interfaces.py:15
-msgid "What is 10 + 4 ?"
-msgstr "Quanto fa 10 + 4 ?"
-
-#: ./browser/interfaces.py:14
-msgid "What is 4 + 4 ?"
-msgstr "Quanto fa 4 + 4 ?"
-
-#: ./browser/interfaces.py:16
-msgid "Write five cipher."
-msgstr "Scrivi cinque in cifre."
-
-#: ./validator.py:12
+#: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."
 msgstr "La tua risposta era sbagliata, prego rispondi alla domanda sottostante."
 
@@ -122,7 +117,7 @@ msgstr "La tua risposta era sbagliata, prego rispondi alla domanda sottostante."
 msgid "You entered an invalid email address."
 msgstr "Hai inserito un messaggio e-mail non valido."
 
-#: ./norobots_input.pt:7
+#: ./browser/norobots_macro.pt:37
+#: ./norobots_input.pt:14
 msgid "Your answer"
 msgstr "La tua risposta"
-

--- a/src/collective/z3cform/norobots/locales/manual.pot
+++ b/src/collective/z3cform/norobots/locales/manual.pot
@@ -15,7 +15,7 @@ msgstr ""
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: collective.pfg.norobots\n"
+"Domain: collective.z3cform.norobots\n"
 
 #: Profile title in configure.zcml
 msgid "Norobots captcha field (collective.z3cform.norobots)"

--- a/src/collective/z3cform/norobots/locales/manual.pot
+++ b/src/collective/z3cform/norobots/locales/manual.pot
@@ -24,3 +24,16 @@ msgstr ""
 #: Profile description in configure.zcml
 msgid "Provides a human captcha widget based on a list of questions/answers."
 msgstr ""
+
+#: Default question 1
+msgid "What is 4 + 4 ?"
+msgstr ""
+
+#: Default question 2
+msgid "Write five cipher."
+msgstr ""
+
+#: Default question 3
+msgid "What is 10 + 4 ?"
+msgstr ""
+

--- a/src/collective/z3cform/norobots/locales/nl/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/nl/LC_MESSAGES/collective.z3cform.norobots.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-04-09 10:58+0000\n"
+"POT-Creation-Date: 2020-06-24 07:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Maarten Kling <maarten@fourdigits.nl>\n"
 "Language-Team: Nederlands\n"
@@ -14,104 +14,99 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.z3cform.norobots\n"
 
-#: ./plone_forms/contact_info.py:32
+#: ./browser/norobots_macro.pt:18
+#: ./plone_forms/contact_info.py:43
 msgid "Are you a human ?"
 msgstr "Ben je een mens ?"
 
-#: ./plone_forms/contact_info.py:42
+#: ./plone_forms/contact_info.py:55
 msgid "Contact form"
 msgstr "Contact formulier"
 
-#: ./plone_forms/contact_info.py:19
+#: ./plone_forms/contact_info.py:24
 msgid "E-Mail"
 msgstr "E-Mail"
 
-#: ./plone_forms/contact_info.py:33
+#: ./browser/norobots_macro.pt:28
+#: ./plone_forms/contact_info.py:44
 msgid "In order to avoid spam, please answer the question below."
 msgstr "Om spam te voorkomen, beantwoord de onderstaande vraag."
 
-#: ./plone_forms/contact_info.py:132
+#: ./plone_forms/contact_info.py:149
 msgid "Mail sent."
 msgstr "Mail verzonden."
 
-#: ./plone_forms/contact_info.py:28
+#: ./plone_forms/contact_info.py:37
 msgid "Message"
 msgstr "Bericht"
 
-#: ./plone_forms/contact_info.py:15
+#: ./plone_forms/contact_info.py:20
 msgid "Name"
 msgstr "Naam"
 
-#: Profile title in configure.zcml
+#: ./configure.zcml:51
 msgid "Norobots captcha field (collective.z3cform.norobots)"
 msgstr ""
 
-#: ./browser/interfaces.py:9
+#: ./configure.zcml:60
+msgid "Norobots captcha field UNINSTALLATION"
+msgstr ""
+
+#: ./browser/interfaces.py:11
 msgid "Norobots question::answer"
 msgstr "Norobots vraag::antwoord"
 
-#: ./browser/controlpanel.py:17
+#: ./browser/controlpanel.py:19
 #: ./profiles/default/controlpanel.xml
 msgid "Norobots widget settings"
 msgstr "Norobots widget instellingen"
 
-#: ./plone_forms/contact_info.py:83
+#: ./plone_forms/contact_info.py:96
 msgid "Please correct the indicated errors and don't forget to fill in the field 'Are you a human ?'."
 msgstr "Verbeter aangegeven fouten, vergeet niet het veld 'Ben je een mens ?'."
 
-#: ./plone_forms/contact_info.py:29
+#: ./plone_forms/contact_info.py:38
 msgid "Please enter the message you want to send."
 msgstr "Geef een "
 
-#: ./plone_forms/contact_info.py:25
+#: ./plone_forms/contact_info.py:32
 msgid "Please enter the subject of the message you want to send."
 msgstr "Onderwerp van het bericht dat je wilt sturen."
 
-#: ./plone_forms/contact_info.py:20
+#: ./plone_forms/contact_info.py:25
 msgid "Please enter your e-mail address."
 msgstr "Geef je email adres."
 
-#: ./plone_forms/contact_info.py:16
+#: ./plone_forms/contact_info.py:20
 msgid "Please enter your full name."
 msgstr "Geef je volledige naam."
 
-#: Profile description in configure.zcml
+#: ./configure.zcml:51
 msgid "Provides a human captcha widget based on a list of questions/answers."
 msgstr ""
 
-#: ./norobots_input.pt:3
+#: ./browser/norobots_macro.pt:32
+#: ./norobots_input.pt:6
 msgid "Question"
 msgstr "Vraag"
 
-#: ./browser/interfaces.py:10
+#: ./browser/interfaces.py:12
 msgid "Questions list (one per line). Example : 'What is 10 + 12 ?::22'. Answer can contain multiple values delimited by semicolon. Example : 'What is 5 + 5 ?::10;ten'."
 msgstr "Vragen lijst (een per regel). Voorbeeld : 'Wat is 10 + 12 ?::22'. Vraag kan meerdere antwoorden hebben door de waarden te splitten met een puntkomma. Voorbeeld: 'Wat is 5 + 5 ?::10;tien'."
 
-#: ./plone_forms/contact_info.py:77
+#: ./configure.zcml:60
+msgid "Removes the human usable captcha widget based on a list of questions/answers."
+msgstr ""
+
+#: ./plone_forms/contact_info.py:90
 msgid "Send"
 msgstr "Verzend"
 
-#: ./plone_forms/contact_info.py:24
+#: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "Onderwerp"
 
-#: ./plone_forms/contact_info.py:127
-msgid "Unable to send mail: ${exception}"
-msgstr "Kan mail niet zenden: ${exception}"
-
-#: ./browser/interfaces.py:15
-msgid "What is 10 + 4 ?"
-msgstr "Wat is 10 + 4 ?"
-
-#: ./browser/interfaces.py:14
-msgid "What is 4 + 4 ?"
-msgstr "Wat is 4 + 4 ?"
-
-#: ./browser/interfaces.py:16
-msgid "Write five cipher."
-msgstr "Schrijf cijfer vijf."
-
-#: ./validator.py:12
+#: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."
 msgstr "Je hebt een verkeerd antwoord gegeven, beantwoord de nieuwe vraag."
 
@@ -119,7 +114,7 @@ msgstr "Je hebt een verkeerd antwoord gegeven, beantwoord de nieuwe vraag."
 msgid "You entered an invalid email address."
 msgstr "Je hebt een verkeerd email adres gegeven."
 
-#: ./norobots_input.pt:7
+#: ./browser/norobots_macro.pt:37
+#: ./norobots_input.pt:14
 msgid "Your answer"
 msgstr "Je antwoord"
-

--- a/src/collective/z3cform/norobots/locales/nl/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/nl/LC_MESSAGES/collective.z3cform.norobots.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-06-24 07:33+0000\n"
+"POT-Creation-Date: 2020-06-24 08:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Maarten Kling <maarten@fourdigits.nl>\n"
 "Language-Team: Nederlands\n"
@@ -105,6 +105,18 @@ msgstr "Verzend"
 #: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "Onderwerp"
+
+#: Default question 3
+msgid "What is 10 + 4 ?"
+msgstr "Wat is 10 + 4 ?"
+
+#: Default question 1
+msgid "What is 4 + 4 ?"
+msgstr "Wat is 4 + 4 ?"
+
+#: Default question 2
+msgid "Write five cipher."
+msgstr "Schrijf cijfer vijf."
 
 #: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."

--- a/src/collective/z3cform/norobots/locales/ru/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/ru/LC_MESSAGES/collective.z3cform.norobots.po
@@ -4,135 +4,122 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2016-07-12 16:15+0500\n"
+"POT-Creation-Date: 2020-06-24 07:33+0000\n"
 "PO-Revision-Date: 2016-07-12 17:53+0500\n"
+"Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "Language-Code: ru\n"
 "Language-Name: Russian\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: collective.pfg.norobots\n"
+"Domain: collective.z3cform.norobots\n"
 "X-Generator: Poedit 1.8.7\n"
-"Last-Translator: \n"
 "Language: ru_RU\n"
 
-#: plone_forms/contact_info.py:32
+#: ./browser/norobots_macro.pt:18
+#: ./plone_forms/contact_info.py:43
 msgid "Are you a human ?"
 msgstr "Вы человек?"
 
-#: plone_forms/contact_info.py:42
+#: ./plone_forms/contact_info.py:55
 msgid "Contact form"
 msgstr "Контактная форма"
 
-#: plone_forms/contact_info.py:19
+#: ./plone_forms/contact_info.py:24
 msgid "E-Mail"
 msgstr "Адрес эл.почты"
 
-#: plone_forms/contact_info.py:33
+#: ./browser/norobots_macro.pt:28
+#: ./plone_forms/contact_info.py:44
 msgid "In order to avoid spam, please answer the question below."
 msgstr "Во избежание спама, пожалуйста, ответьте на вопрос ниже."
 
-#: plone_forms/contact_info.py:132
+#: ./plone_forms/contact_info.py:149
 msgid "Mail sent."
 msgstr "Письмо отправлено."
 
-#: plone_forms/contact_info.py:28
+#: ./plone_forms/contact_info.py:37
 msgid "Message"
 msgstr "Сообщение"
 
-#: plone_forms/contact_info.py:15
+#: ./plone_forms/contact_info.py:20
 msgid "Name"
 msgstr "Имя"
 
-#: Profile title in configure.zcml
+#: ./configure.zcml:51
 msgid "Norobots captcha field (collective.z3cform.norobots)"
 msgstr "Капча Norobots"
 
-#: browser/interfaces.py:9
+#: ./configure.zcml:60
+msgid "Norobots captcha field UNINSTALLATION"
+msgstr ""
+
+#: ./browser/interfaces.py:11
 msgid "Norobots question::answer"
 msgstr "Norobots вопрос::ответ"
 
-#: browser/controlpanel.py:17 profiles/default/controlpanel.xml
+#: ./browser/controlpanel.py:19
+#: ./profiles/default/controlpanel.xml
 msgid "Norobots widget settings"
 msgstr "Настройки Norobots"
 
-#: plone_forms/contact_info.py:83
-msgid ""
-"Please correct the indicated errors and don't forget to fill in the field "
-"'Are you a human ?'."
-msgstr ""
-"Пожалуйста, исправьте указанные ошибки, и не забудьте заполнить поле 'Вы человек?'."
+#: ./plone_forms/contact_info.py:96
+msgid "Please correct the indicated errors and don't forget to fill in the field 'Are you a human ?'."
+msgstr "Пожалуйста, исправьте указанные ошибки, и не забудьте заполнить поле 'Вы человек?'."
 
-#: plone_forms/contact_info.py:29
+#: ./plone_forms/contact_info.py:38
 msgid "Please enter the message you want to send."
 msgstr "Пожалуйста, введите сообщение, которое вы хотите отправить."
 
-#: plone_forms/contact_info.py:25
+#: ./plone_forms/contact_info.py:32
 msgid "Please enter the subject of the message you want to send."
 msgstr "Пожалуйста, введите тему сообщения, которое вы хотите отправить."
 
-#: plone_forms/contact_info.py:20
+#: ./plone_forms/contact_info.py:25
 msgid "Please enter your e-mail address."
 msgstr "Пожалуйста, введите адрес Ващей электронной почты."
 
-#: plone_forms/contact_info.py:16
+#: ./plone_forms/contact_info.py:20
 msgid "Please enter your full name."
 msgstr "Пожалуйста, введите ваше ФИО."
 
-#: Profile description in configure.zcml
+#: ./configure.zcml:51
 msgid "Provides a human captcha widget based on a list of questions/answers."
 msgstr "Капча на основе списка вопрос-ответ."
 
-#: norobots_input.pt:3
+#: ./browser/norobots_macro.pt:32
+#: ./norobots_input.pt:6
 msgid "Question"
 msgstr "Вопрос"
 
-#: browser/interfaces.py:10
-msgid ""
-"Questions list (one per line). Example : 'What is 10 + 12 ?::22'. Answer can "
-"contain multiple values delimited by semicolon. Example : 'What is 5 + "
-"5 ?::10;ten'."
-msgstr ""
-"Список вопросов (по одному в строке). Пример: 'Сколько будет 10 + 12 ?::22'. "
-"Ответ может содержать несколько значений, разделенных точкой с запятой. "
-"Пример: 'Сколько будет  5 + 5 ?::10;десять."
+#: ./browser/interfaces.py:12
+msgid "Questions list (one per line). Example : 'What is 10 + 12 ?::22'. Answer can contain multiple values delimited by semicolon. Example : 'What is 5 + 5 ?::10;ten'."
+msgstr "Список вопросов (по одному в строке). Пример: 'Сколько будет 10 + 12 ?::22'. Ответ может содержать несколько значений, разделенных точкой с запятой. Пример: 'Сколько будет  5 + 5 ?::10;десять."
 
-#: plone_forms/contact_info.py:77
+#: ./configure.zcml:60
+msgid "Removes the human usable captcha widget based on a list of questions/answers."
+msgstr ""
+
+#: ./plone_forms/contact_info.py:90
 msgid "Send"
 msgstr "Отправить"
 
-#: plone_forms/contact_info.py:24
+#: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "Тема сообщения"
 
-#: plone_forms/contact_info.py:127
-msgid "Unable to send mail: ${exception}"
-msgstr "Невозможно отправить почту: ${exception}"
-
-#: browser/interfaces.py:15
-msgid "What is 10 + 4 ?"
-msgstr "Сколько будет 10 + 4 ?"
-
-#: browser/interfaces.py:14
-msgid "What is 4 + 4 ?"
-msgstr "Сколько будет 4 + 4 ?"
-
-#: browser/interfaces.py:16
-msgid "Write five cipher."
-msgstr "Напишите пять цифрой"
-
-#: validator.py:12
+#: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."
 msgstr "Вы ввели неправильный ответ, пожалуйста, ответьте на вопрос ниже."
 
-#: plone_forms/constraints.py:10
+#: ./plone_forms/constraints.py:10
 msgid "You entered an invalid email address."
 msgstr "Вы ввели неправильный адрес электронной почты."
 
-#: norobots_input.pt:7
+#: ./browser/norobots_macro.pt:37
+#: ./norobots_input.pt:14
 msgid "Your answer"
 msgstr "Ваш ответ"

--- a/src/collective/z3cform/norobots/locales/ru/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/ru/LC_MESSAGES/collective.z3cform.norobots.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2020-06-24 07:33+0000\n"
+"POT-Creation-Date: 2020-06-24 08:09+0000\n"
 "PO-Revision-Date: 2016-07-12 17:53+0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -110,6 +110,18 @@ msgstr "Отправить"
 #: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "Тема сообщения"
+
+#: Default question 3
+msgid "What is 10 + 4 ?"
+msgstr "Сколько будет 10 + 4 ?"
+
+#: Default question 1
+msgid "What is 4 + 4 ?"
+msgstr "Сколько будет 4 + 4 ?"
+
+#: Default question 2
+msgid "Write five cipher."
+msgstr "Напишите пять цифрой"
 
 #: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."

--- a/src/collective/z3cform/norobots/locales/zh_CN/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/zh_CN/LC_MESSAGES/collective.z3cform.norobots.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.z3cform.norobots\n"
-"POT-Creation-Date: 2013-04-09 10:58+0000\n"
+"POT-Creation-Date: 2020-06-24 07:33+0000\n"
 "PO-Revision-Date: 2012-03-27 17:27 +0800\n"
 "Last-Translator: Jian Aijun <jianaijun@gmail.com>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sf.net>\n"
@@ -16,104 +16,99 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.z3cform.norobots\n"
 
-#: ./plone_forms/contact_info.py:32
+#: ./browser/norobots_macro.pt:18
+#: ./plone_forms/contact_info.py:43
 msgid "Are you a human ?"
 msgstr "您是人类吗？"
 
-#: ./plone_forms/contact_info.py:42
+#: ./plone_forms/contact_info.py:55
 msgid "Contact form"
 msgstr "联系表"
 
-#: ./plone_forms/contact_info.py:19
+#: ./plone_forms/contact_info.py:24
 msgid "E-Mail"
 msgstr "电子邮件"
 
-#: ./plone_forms/contact_info.py:33
+#: ./browser/norobots_macro.pt:28
+#: ./plone_forms/contact_info.py:44
 msgid "In order to avoid spam, please answer the question below."
 msgstr "为了避免垃圾邮件，请回答以下问题。"
 
-#: ./plone_forms/contact_info.py:132
+#: ./plone_forms/contact_info.py:149
 msgid "Mail sent."
 msgstr "发送邮件"
 
-#: ./plone_forms/contact_info.py:28
+#: ./plone_forms/contact_info.py:37
 msgid "Message"
 msgstr "内容"
 
-#: ./plone_forms/contact_info.py:15
+#: ./plone_forms/contact_info.py:20
 msgid "Name"
 msgstr "名称"
 
-#: Profile title in configure.zcml
+#: ./configure.zcml:51
 msgid "Norobots captcha field (collective.z3cform.norobots)"
 msgstr ""
 
-#: ./browser/interfaces.py:9
+#: ./configure.zcml:60
+msgid "Norobots captcha field UNINSTALLATION"
+msgstr ""
+
+#: ./browser/interfaces.py:11
 msgid "Norobots question::answer"
 msgstr ""
 
-#: ./browser/controlpanel.py:17
+#: ./browser/controlpanel.py:19
 #: ./profiles/default/controlpanel.xml
 msgid "Norobots widget settings"
 msgstr ""
 
-#: ./plone_forms/contact_info.py:83
+#: ./plone_forms/contact_info.py:96
 msgid "Please correct the indicated errors and don't forget to fill in the field 'Are you a human ?'."
 msgstr """请更正指示的错误，别忘了填写字段 "您是人类吗？"。"""
 
-#: ./plone_forms/contact_info.py:29
+#: ./plone_forms/contact_info.py:38
 msgid "Please enter the message you want to send."
 msgstr "请输入您要发送的内容。"
 
-#: ./plone_forms/contact_info.py:25
+#: ./plone_forms/contact_info.py:32
 msgid "Please enter the subject of the message you want to send."
 msgstr "请输入您要发送的内容的主题。"
 
-#: ./plone_forms/contact_info.py:20
+#: ./plone_forms/contact_info.py:25
 msgid "Please enter your e-mail address."
 msgstr "请输入您的电子邮件地址。"
 
-#: ./plone_forms/contact_info.py:16
+#: ./plone_forms/contact_info.py:20
 msgid "Please enter your full name."
 msgstr "请输入您的全名。"
 
-#: Profile description in configure.zcml
+#: ./configure.zcml:51
 msgid "Provides a human captcha widget based on a list of questions/answers."
 msgstr ""
 
-#: ./norobots_input.pt:3
+#: ./browser/norobots_macro.pt:32
+#: ./norobots_input.pt:6
 msgid "Question"
 msgstr "问题"
 
-#: ./browser/interfaces.py:10
+#: ./browser/interfaces.py:12
 msgid "Questions list (one per line). Example : 'What is 10 + 12 ?::22'. Answer can contain multiple values delimited by semicolon. Example : 'What is 5 + 5 ?::10;ten'."
 msgstr ""
 
-#: ./plone_forms/contact_info.py:77
+#: ./configure.zcml:60
+msgid "Removes the human usable captcha widget based on a list of questions/answers."
+msgstr ""
+
+#: ./plone_forms/contact_info.py:90
 msgid "Send"
 msgstr "发送"
 
-#: ./plone_forms/contact_info.py:24
+#: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "主题"
 
-#: ./plone_forms/contact_info.py:127
-msgid "Unable to send mail: ${exception}"
-msgstr "无法发送邮件： ${exception}"
-
-#: ./browser/interfaces.py:15
-msgid "What is 10 + 4 ?"
-msgstr "10 + 4 等于几？"
-
-#: ./browser/interfaces.py:14
-msgid "What is 4 + 4 ?"
-msgstr "4 + 4 等于几？"
-
-#: ./browser/interfaces.py:16
-msgid "Write five cipher."
-msgstr """ "五" 的数字是什么？"""
-
-#: ./validator.py:12
+#: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."
 msgstr "您输入了错误的答案，请回答下面的新问题。"
 
@@ -121,7 +116,7 @@ msgstr "您输入了错误的答案，请回答下面的新问题。"
 msgid "You entered an invalid email address."
 msgstr ""
 
-#: ./norobots_input.pt:7
+#: ./browser/norobots_macro.pt:37
+#: ./norobots_input.pt:14
 msgid "Your answer"
 msgstr "您的答案"
-

--- a/src/collective/z3cform/norobots/locales/zh_CN/LC_MESSAGES/collective.z3cform.norobots.po
+++ b/src/collective/z3cform/norobots/locales/zh_CN/LC_MESSAGES/collective.z3cform.norobots.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.z3cform.norobots\n"
-"POT-Creation-Date: 2020-06-24 07:33+0000\n"
+"POT-Creation-Date: 2020-06-24 08:09+0000\n"
 "PO-Revision-Date: 2012-03-27 17:27 +0800\n"
 "Last-Translator: Jian Aijun <jianaijun@gmail.com>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sf.net>\n"
@@ -107,6 +107,18 @@ msgstr "发送"
 #: ./plone_forms/contact_info.py:31
 msgid "Subject"
 msgstr "主题"
+
+#: Default question 3
+msgid "What is 10 + 4 ?"
+msgstr "10 + 4 等于几？"
+
+#: Default question 1
+msgid "What is 4 + 4 ?"
+msgstr "4 + 4 等于几？"
+
+#: Default question 2
+msgid "Write five cipher."
+msgstr """ "五" 的数字是什么？"""
 
 #: ./validator.py:9
 msgid "You entered a wrong answer, please answer the new question below."


### PR DESCRIPTION
Updated the translation catalog (which hasn't done in the last 8 years).

Also I added the default “en” translation. If that is missing in a multilingual site where only some translations are active (e.g. german and english), than the default english will fallback to the first available translation (in that example german).

So even when english gets never translated (because it is the source), it needs to be available as translation.